### PR TITLE
Use Trusted Publishing for NuGet

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [release/*]
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,11 +9,15 @@ on:
       - main
       - renovate/**
 
+permissions: {}
+
 jobs:
   test-publish-nuget:
     name: It publishes NuGet packages
     runs-on: ubuntu-latest
     environment: Publish to NuGet.org
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -27,5 +31,4 @@ jobs:
       - name: Test the action
         uses: ./
         with:
-          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
           working-directory: "test"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,13 @@ jobs:
       - name: Set unique package version
         run: echo "VERSION=0.0.${GITHUB_RUN_NUMBER}-pre" >> $GITHUB_ENV
         working-directory: "test"
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Test the action
         uses: ./
         with:
+          nuget-api-key: ${{ steps.login.outputs.NUGET_API_KEY }}
           working-directory: "test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Switch to trusted publishing
 
 ## [1.0.0] - 2022-01-04
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ jobs:
     name: Publish package to NuGet.org
     runs-on: ubuntu-latest
     environment: Release
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # action-publish-nuget
 
-Publishes a .NET package to [NuGet.org](https://nuget.org/)
+Publishes a .NET package to [NuGet.org](https://nuget.org/) using [trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing).
 
 Needs .NET to be installed first.
 
@@ -32,8 +32,13 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x
-      - uses: cucumber/action-publish-nuget@v1.0.0
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1.2.0
+        id: login
         with:
-          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
+          user: ${{ secrets.NUGET_USER }}
+      - uses: cucumber/action-publish-nuget@v2.0.0
+        with:
+          nuget-api-key: ${{ steps.login.outputs.NUGET_API_KEY }}
           working-directory: "dotnet"
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -1,10 +1,9 @@
 name: 'Publish to NuGet.org'
 description: 'Publish a .NET package to NuGet.org'
 inputs:
-  nuget-user:
-    description: NuGet User
-    required: false
-    default: "cukebot"
+  nuget-api-key:
+    description: NuGet API Key
+    required: true
   working-directory:
     description: "Path within the repo to the folder where the .NET project lives"
     required: false
@@ -21,17 +20,12 @@ runs:
       run: dotnet pack --configuration Release --no-build --output NuGetOut
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-    - name: NuGet login (OIDC → temp API key)
-      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
-      id: login
-      with:
-        user: ${{ inputs.nuget-user }}
     - name: Push
-      run: dotnet nuget push NuGetOut/*.nupkg --api-key "${NUGET_API_KEY}" --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push NuGetOut/*.nupkg --api-key ${NUGET_API_KEY} --source https://api.nuget.org/v3/index.json
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
-        NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ inputs.nuget-api-key }}
 
 branding:
   icon: package

--- a/action.yaml
+++ b/action.yaml
@@ -1,9 +1,10 @@
 name: 'Publish to NuGet.org'
 description: 'Publish a .NET package to NuGet.org'
 inputs:
-  nuget-api-key:
-    description: NuGet API Key
-    required: true
+  nuget-user:
+    description: NuGet User
+    required: false
+    default: "cukebot"
   working-directory:
     description: "Path within the repo to the folder where the .NET project lives"
     required: false
@@ -20,12 +21,17 @@ runs:
       run: dotnet pack --configuration Release --no-build --output NuGetOut
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      id: login
+      with:
+        user: ${{ inputs.nuget-user }}
     - name: Push
-      run: dotnet nuget push NuGetOut/*.nupkg --api-key ${NUGET_API_KEY} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push NuGetOut/*.nupkg --api-key "${NUGET_API_KEY}" --source https://api.nuget.org/v3/index.json
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
-        NUGET_API_KEY: ${{ inputs.nuget-api-key }}
+        NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
 branding:
   icon: package


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Work towards https://github.com/cucumber/common/issues/2282.

Oddly enough, this doesn't actually require a change in the implementation of the action itself. The login action can be added externally.

### 🏷️ What kind of change is this?

- :boom: Breaking change (incompatible changes to the API)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
